### PR TITLE
Improve stats display

### DIFF
--- a/app.py
+++ b/app.py
@@ -439,11 +439,11 @@ if dist is not None:
             f"(niveau de confiance {params.conf*100:.0f} %)."
         )
         q25, q50, q75 = np.percentile(dist, [25, 50, 75])
-        st.write(
-            f"Minimum : {dist.min():.1f} m\n"
-            f"1er quartile : {q25:.1f} m\n"
-            f"Médiane : {q50:.1f} m\n"
-            f"3e quartile : {q75:.1f} m\n"
+        st.markdown(
+            f"Minimum : {dist.min():.1f} m  \n"
+            f"1er quartile : {q25:.1f} m  \n"
+            f"Médiane : {q50:.1f} m  \n"
+            f"3e quartile : {q75:.1f} m  \n"
             f"Maximum : {dist.max():.1f} m"
         )
         fig_box = px.box(


### PR DESCRIPTION
## Summary
- break lines in statistics output using `st.markdown`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845f5907c8883298439f56b213be184