### PR TITLE
Fix Streamlit rerun compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,7 +245,10 @@ if st.button("🚀 Lancer la démo", key="demo"):
         dist_demo = run_mc(demo_params, batch=5_000, max_iter=1)
     st.session_state["dist"] = dist_demo
     st.session_state["params"] = demo_params
-    st.experimental_rerun()
+    if hasattr(st, "rerun"):
+        st.rerun()
+    elif hasattr(st, "experimental_rerun"):
+        st.experimental_rerun()
 
 # ==============================================================
 # 4. Interface Streamlit


### PR DESCRIPTION
## Summary
- support different Streamlit versions when rerunning

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845f9656f6c83298bf04c1a7cb10e17