### PR TITLE
Remove quick demo option

### DIFF
--- a/app.py
+++ b/app.py
@@ -383,11 +383,6 @@ with tab_accueil:
         "La somme des deux donne la **distance d'arrêt**."
     )
 
-    st.markdown("### Prêt à tester ?")
-    if st.button("▶️ Lancer la démo rapide"):
-        st.experimental_set_query_params(page="dashboard")
-        st.experimental_rerun()
-
     st.markdown(
         """
         <small>


### PR DESCRIPTION
## Summary
- remove the 'Prêt à tester ?' heading and quick demo button

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846027c1be08329a2524d4e4c7b88f4