### PR TITLE
Remove redundant WCAG note

### DIFF
--- a/app.py
+++ b/app.py
@@ -392,15 +392,6 @@ with tab_accueil:
         "La somme des deux donne la **distance d'arrêt**."
     )
 
-    st.markdown(
-        """
-        <small>
-        Couleurs conformes WCAG AA – navigation clavier possible – mobile friendly
-        </small>
-        """,
-        unsafe_allow_html=True,
-    )
-
 # --------------------------------------------------------------
 # 5. Exécution / affichage
 # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove reference to WCAG/keyboard/mobile note from app

## Testing
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847dd5114bc8329859c01238ee89dbc