### PR TITLE
Add theoretical max to stats tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -531,12 +531,19 @@ if dist is not None:
         else:
             st.write("La collision est quasi impossible.")
         q25, q50, q75 = np.percentile(dist, [25, 50, 75])
+        max_theo = stopping_distance(
+            np.array([params.speed]),
+            np.array([3.0]),
+            np.array([mu_bounds(base_mu(params.surface, params.tyre))[0]]),
+            np.array([SLOPE[params.slope] - 1]),
+        )[0]
         st.markdown(
             f"Minimum : {dist.min():.1f} m  \n"
             f"1er quartile : {q25:.1f} m  \n"
             f"Médiane : {q50:.1f} m  \n"
             f"3e quartile : {q75:.1f} m  \n"
-            f"Maximum : {dist.max():.1f} m"
+            f"Maximum : {dist.max():.1f} m  \n"
+            f"Maximum théorique : {max_theo:.1f} m"
         )
         fig_box = px.box(
             dist,


### PR DESCRIPTION
## Summary
- display theoretical maximum stopping distance in Stats tab

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847df90c0e4832980e9d1959894f47c