### PR TITLE
Remove histogram legend

### DIFF
--- a/app.py
+++ b/app.py
@@ -470,7 +470,7 @@ if dist is not None:
             xaxis_title="Distance d'arrêt (m)",
             yaxis_title="Part des simulations (%)",
             legend_title_text="",
-            showlegend=True,
+            showlegend=False,
             annotations=[],
             margin=dict(b=80),
             meta={


### PR DESCRIPTION
## Summary
- hide the legend for the histogram titled "Répartition des distances d'arrêt observées"

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684827299ce883299d8111519e1af6db