### PR TITLE
Fix Streamlit config order

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,16 +19,15 @@ import math
 import time
 import qrcode
 
-
-user_id = st.secrets["ID"]
-password = st.secrets["MDP"]
-st.write(f"ID chargé : {user_id}")
-
 st.set_page_config(
     page_title="Simulateur – Distance d’arrêt",
     page_icon="🚗",
     layout="wide",
 )
+
+user_id = st.secrets["ID"]
+password = st.secrets["MDP"]
+st.write(f"ID chargé : {user_id}")
 
 st.title("Simulateur de distance d'arrêt")
 


### PR DESCRIPTION
## Summary
- call `st.set_page_config` before using any Streamlit UI elements

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68482ed317288329affaf725297d616c