### PR TITLE
Add authors to About page

### DIFF
--- a/app.py
+++ b/app.py
@@ -815,6 +815,12 @@ with tab_about:
     else:
         st.info("Aucune simulation pour l'instant.")
 
+    st.markdown("### Auteurs")
+    st.markdown(
+        "Ce calculateur a été réalisé par **Mohamed MOSTEFAOUI** "
+        "et **Elouan LE GUYADER** – Toulouse INP‑ENSIACET."
+    )
+
 # ------------------ Partager ----------------------------------
 with tab_share:
     st.markdown("### Partager l'application")


### PR DESCRIPTION
## Summary
- show authors in the about tab

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68553b3e2be48329a61d8fbb43c8ba1e